### PR TITLE
fix(index): add missing slash to default distfolder path fixes #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Add `nuxt-twa-module` to `modules` section of `nuxt.config.js`.
         /* optional */
         /* overwrite default location for icon */
         iconPath: '/static/icon.png'
+        /* Overwrite folder where to put .wellknown */
+        distFolder: '.nuxt/dist/client',
       }],
     ]
   }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add `nuxt-twa-module` to `modules` section of `nuxt.config.js`.
         /* module options */
         defaultUrl: 'https://your-url.com',
         hostName: 'your-url.com',
-        sha256Fingerprints: [/* your SHA-256 keys */],
+        sha256Fingerprints: ['/* your SHA-256 keys */'],
         applicationId: 'com.example.example',
         launcherName: 'Your app name',
         versionCode: 1,
@@ -57,6 +57,8 @@ Add `nuxt-twa-module` to `modules` section of `nuxt.config.js`.
     ]
   }
 ```
+
+the `sha256Fingerprints` by is an array with one SHA-256 key string. But if you have multiple you can add them to the array. More information about the website asociation: https://developer.android.com/training/app-links/verify-site-associations#web-assoc
 
 ## Time to build 🏗
 
@@ -75,7 +77,7 @@ npm run generate
 ### Output
 
 - An `android` folder in your project root, which you can open in Android Studio to [build your app](https://developer.android.com/studio/run/). When you've build and tested your app you can use [Generate Signed Bundle/APK](https://developer.android.com/studio/publish/app-signing). This will generate a .aab file that can be uploaded to the Google Play Store.
-- You Nuxt app with an added `.well-known` folder which is needed to make your domain trusted with the app in the store.
+- Your Nuxt app with an added `.well-known` folder which is needed to make your domain trusted with the app in the store.
 
 ## Debug
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const rimraf = require('rimraf')
 const consola = require('consola')
 const ncp = require('ncp')
-const tmp  = require('tmp-promise')
+const tmp = require('tmp-promise')
 const asyncRimRaf = promisify(rimraf)
 const asyncNcp = promisify(ncp)
 
@@ -13,7 +13,7 @@ const { generateAssetLinksFile } = require('./lib/generate-asset-links-file')
 
 const moduleRoot = __dirname
 
-module.exports = function nuxtTwa (options) {
+module.exports = function nuxtTwa(options) {
   const { rootDir } = this.nuxt.options
   const pckg = require(rootDir + '/package.json')
   const defaultOptions = {
@@ -22,13 +22,13 @@ module.exports = function nuxtTwa (options) {
     versionCode: Number(String(pckg.version).replace(/\./g, '')),
     versionName: pckg.version,
     iconPath: '/static/icon.png',
-    distFolder: rootDir + '.nuxt/dist/client',
+    distFolder: rootDir + '/.nuxt/dist/client',
     androidFolder: rootDir + '/android',
     statusBarColor: options.statusBarColor || '#fff'
   }
-  
+
   this.nuxt.hook('build:before', async () => {
-  
+
     options = {
       ...defaultOptions,
       ...options,
@@ -36,12 +36,12 @@ module.exports = function nuxtTwa (options) {
 
     let tempDir
     let tmpRes
-    
+
     try {
       tmpRes = await tmp.dir()
       tempDir = tmpRes.path + '/android'
     } catch (err) {
-      throw('Temperary directory generation failed:', err)
+      throw ('Temperary directory generation failed:', err)
     }
 
     try {
@@ -63,7 +63,7 @@ module.exports = function nuxtTwa (options) {
       await generateIcons(iconPath, androidIconsPath)
     } catch (err) {
       return consola.error('Generating icons failed', err)
-    }  
+    }
 
     try {
       await asyncNcp(tempDir, options.androidFolder)

--- a/test/example/nuxt.config.js
+++ b/test/example/nuxt.config.js
@@ -8,13 +8,15 @@ module.exports = {
     resourceHints: false
   },
   modules: [
-    { handler: require('../../'), options: {
-      hostName: 'test.com',
-      defaultUrl: 'https://test.com',
-      sha256Fingerprints: '123',
-      iconPath: '/test/fixture/static/icon.png',
-      distFolder: '/test/example/.nuxt/dist/client',
-      androidFolder: './test/example/android/'
-    } }
+    {
+      handler: require('../../'), options: {
+        hostName: 'test.com',
+        defaultUrl: 'https://test.com',
+        sha256Fingerprints: ['123'],
+        iconPath: '/test/fixture/static/icon.png',
+        distFolder: '/test/example/.nuxt/dist/client',
+        androidFolder: './test/example/android/'
+      }
+    }
   ]
 }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -10,32 +10,32 @@ const { generateAssetLinksFile, generateConfig } = require('../lib/generate-asse
 
 describe('Test TWA module', () => {
     const iconPath = path.resolve(__dirname, 'fixture/static/icon.png')
-    const testFolder =  path.resolve(__dirname, 'test-env')
+    const testFolder = path.resolve(__dirname, 'test-env')
 
     beforeAll(() => {
         // Redirect std and console to consola too
         // Calling this once is sufficient
         consola.wrapAll()
-        if(fs.existsSync(testFolder)){ 
+        if (fs.existsSync(testFolder)) {
             rimraf(testFolder, (error) => console.log(error))
         }
         fs.mkdirSync(testFolder, { recursive: true })
     })
 
-    beforeEach(() => { 
+    beforeEach(() => {
         // Re-mock consola before each test call to remove
         // calls from before
-        consola.mockTypes(() => jest.fn()) 
+        consola.mockTypes(() => jest.fn())
     })
 
-    afterAll( () => {
+    afterAll(() => {
         return rimraf(testFolder, (error) => console.log(error))
     })
 
     describe('Test generate-icons', () => {
-        const destination =  path.resolve(testFolder, 'res/')
+        const destination = path.resolve(testFolder, 'res/')
 
-        beforeAll( () => {
+        beforeAll(() => {
             fs.mkdirSync(destination, { recursive: true })
         })
 
@@ -82,7 +82,7 @@ describe('Test TWA module', () => {
     })
 
     describe('Test generate-build-file', () => {
-        const appDirectory =  path.resolve(__dirname, 'test-env/app')
+        const appDirectory = path.resolve(__dirname, 'test-env/app')
         const gradleFile = path.resolve(__dirname, 'test-env/app/build.gradle')
         const buildOptions = {
             defaultUrl: 'test',
@@ -103,7 +103,7 @@ describe('Test TWA module', () => {
         beforeAll(() => {
             prepareAppFolder(appDirectory)
         })
-        
+
 
         test('Get error when gradle file is undefined', async () => {
             expect.assertions(1)
@@ -156,11 +156,11 @@ describe('Test TWA module', () => {
             }
         })
     })
-    
+
     describe('Test generate-asset-links-file', () => {
         const options = {
             applicationId: "test",
-            sha256Fingerprints: "123"
+            sha256Fingerprints: ["123"]
         }
 
         const mockdata = [{
@@ -168,7 +168,7 @@ describe('Test TWA module', () => {
             "target": {
                 "namespace": "android_app",
                 "package_name": "test",
-                "sha256_cert_fingerprints": "123"
+                "sha256_cert_fingerprints": ["123"]
             },
         }]
 
@@ -178,17 +178,17 @@ describe('Test TWA module', () => {
                 await generateAssetLinksFile({}, '')
             } catch (error) {
                 expect(error)
-                .toMatch(/Missing SHA256/)
+                    .toMatch(/Missing SHA256/)
             }
         })
 
-        test('Get error when destination path is invalid', async() => {
+        test('Get error when destination path is invalid', async () => {
             expect.assertions(1)
             try {
                 await generateAssetLinksFile(options, '')
             } catch (error) {
                 expect(error)
-                .toMatch(/No destination path/)
+                    .toMatch(/No destination path/)
             }
         })
 
@@ -209,5 +209,5 @@ describe('Test TWA module', () => {
         })
     })
 })
- 
+
 


### PR DESCRIPTION
- Add missing slash to distFolder default path to fix #11 
- Add distFolder optional option to README.md
- Add quotes around 256-SHA key in readme to prevent errors
- Add consistent array around 256-SHA key in example
- formatting