### PR TITLE
Update build.grade

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -53,5 +53,5 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.github.GoogleChrome.custom-tabs-client:customtabs:e849e45c90'
+    implementation 'com.github.GoogleChrome.custom-tabs-client:customtabs:b42451a68'
 }


### PR DESCRIPTION
Change custom-tabs-client
There is a bug associated with the browser by default. For example, if Firefox is selected by default, then TWA can't run properly and you can see only a white screen.
bugs.chromium.org/p/chromium/issues/detail?id=942930
And here some fixes from developer 
github.com/GoogleChrome/custom-tabs-client/commit/b42451a6831dfb063c15fca35a461980ba0d2987
